### PR TITLE
Lag gpt with flows

### DIFF
--- a/lag-gpt-flows/__init__.py
+++ b/lag-gpt-flows/__init__.py
@@ -1,0 +1,12 @@
+from .estimator import LagGPTFlowsEstimator
+from .lightning_module import LagGPTFlowsLightningModule
+from .module import LagGPTFlowsModel
+from .aug import freq_mask, freq_mix
+
+__all__ = [
+    "LagGPTFlowsModel",
+    "LagGPTFlowsLightningModule",
+    "LagGPTFlowsEstimator",
+    "freq_mask",
+    "freq_mix",
+]

--- a/lag-gpt-flows/aug.py
+++ b/lag-gpt-flows/aug.py
@@ -1,0 +1,58 @@
+import numpy as np
+import torch
+
+
+@torch.no_grad()
+def freq_mask(x, y, rate=0.1, dim=1):
+    x_len = x.shape[dim]
+    y_len = y.shape[dim]
+    xy = torch.cat([x, y], dim=1)
+    xy_f = torch.fft.rfft(xy, dim=dim)
+    m = torch.rand_like(xy_f, dtype=xy.dtype) < rate
+
+    freal = xy_f.real.masked_fill(m, 0)
+    fimag = xy_f.imag.masked_fill(m, 0)
+    xy_f = torch.complex(freal, fimag)
+    xy = torch.fft.irfft(xy_f, dim=dim)
+
+    if x_len + y_len != xy.shape[dim]:
+        xy = torch.cat([x[:, 0:1, ...], xy], 1)
+
+    return torch.split(xy, [x_len, y_len], dim=dim)
+
+
+@torch.no_grad()
+def freq_mix(x, y, rate=0.1, dim=1):
+    x_len = x.shape[dim]
+    y_len = y.shape[dim]
+    xy = torch.cat([x, y], dim=dim)
+    xy_f = torch.fft.rfft(xy, dim=dim)
+
+    m = torch.rand_like(xy_f, dtype=xy.dtype) < rate
+    amp = abs(xy_f)
+    _, index = amp.sort(dim=dim, descending=True)
+    dominant_mask = index > 2
+    m = torch.bitwise_and(m, dominant_mask)
+    freal = xy_f.real.masked_fill(m, 0)
+    fimag = xy_f.imag.masked_fill(m, 0)
+
+    b_idx = np.arange(x.shape[0])
+    np.random.shuffle(b_idx)
+    x2, y2 = x[b_idx], y[b_idx]
+    xy2 = torch.cat([x2, y2], dim=dim)
+    xy2_f = torch.fft.rfft(xy2, dim=dim)
+
+    m = torch.bitwise_not(m)
+    freal2 = xy2_f.real.masked_fill(m, 0)
+    fimag2 = xy2_f.imag.masked_fill(m, 0)
+
+    freal += freal2
+    fimag += fimag2
+
+    xy_f = torch.complex(freal, fimag)
+    xy = torch.fft.irfft(xy_f, dim=dim)
+
+    if x_len + y_len != xy.shape[dim]:
+        xy = torch.cat([x[:, 0:1, ...], xy], 1)
+
+    return torch.split(xy, [x_len, y_len], dim=dim)

--- a/lag-gpt-flows/configs/config.yaml
+++ b/lag-gpt-flows/configs/config.yaml
@@ -1,0 +1,28 @@
+dataset:
+  val: m4_weekly
+  test: traffic
+  weighted: 0
+gpt:
+  max_epochs: 1
+  context_length: 1024
+  n_layer: 8
+  n_embd: 64
+  n_head: 4
+  scaling: std
+  lr: 0.001
+  weight_decay: 0.00000001
+  aug_prob: 0.5
+  aug_rate: 0.1
+  num_parallel_samples: 100
+  batch_size: 32
+  batches_per_epoch: 10000
+  dsf_marginal:
+    mlp_layers: 4
+    mlp_dim: 32
+    flow_layers: 4
+    flow_hid_dim: 32
+CUDA:
+  device_id: 0
+metrics:
+  logger: csv
+  num_steps: 1

--- a/lag-gpt-flows/estimator.py
+++ b/lag-gpt-flows/estimator.py
@@ -1,0 +1,259 @@
+from typing import Optional, Iterable, Dict, Any
+
+import torch
+import pytorch_lightning as pl
+
+from gluonts.core.component import validated
+from gluonts.dataset.common import Dataset
+from gluonts.dataset.field_names import FieldName
+from gluonts.dataset.loader import as_stacked_batches
+from gluonts.dataset.stat import calculate_dataset_statistics
+from gluonts.itertools import Cyclic
+from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
+from gluonts.transform import (
+    Chain,
+    Transformation,
+    ValidationSplitSampler,
+    TestSplitSampler,
+    AddObservedValuesIndicator,
+    ExpectedNumInstanceSampler,
+    DummyValueImputation,
+    InstanceSampler,
+    InstanceSplitter,
+)
+from gluonts.torch.model.estimator import PyTorchLightningEstimator
+from gluonts.torch.model.predictor import PyTorchPredictor
+from gluonts.torch.distributions import DistributionOutput, StudentTOutput
+
+from lightning_module import LagGPTFlowsLightningModule
+
+PREDICTION_INPUT_NAMES = ["past_target", "past_observed_values"]
+
+TRAINING_INPUT_NAMES = PREDICTION_INPUT_NAMES + [
+    "future_target",
+    "future_observed_values",
+]
+
+
+class LagGPTFlowsEstimator(PyTorchLightningEstimator):
+    """
+    An estimator training a ConvTSMixer model for forecasting.
+
+    This class is uses the model defined in ``ConvTSMixerModel``,
+    and wraps it into a ``ConvTSMixerLightningModule`` for training
+    purposes: training is performed using PyTorch Lightning's ``pl.Trainer``
+    class.
+
+    Parameters
+    ----------
+    prediction_length
+        Length of the prediction horizon.
+    context_length
+        Number of time steps prior to prediction time that the model
+        takes as inputs (default: ``10 * prediction_length``).
+    lr
+        Learning rate (default: ``1e-3``).
+    weight_decay
+        Weight decay regularization parameter (default: ``1e-8``).
+    loss
+        Loss to be optimized during training
+        (default: ``NegativeLogLikelihood()``).
+    batch_norm
+        Whether to apply batch normalization.
+    batch_size
+        The size of the batches to be used for training (default: 32).
+    num_batches_per_epoch
+        Number of batches to be processed in each training epoch
+            (default: 50).
+    trainer_kwargs
+        Additional arguments to provide to ``pl.Trainer`` for construction.
+    train_sampler
+        Controls the sampling of windows during training.
+    validation_sampler
+        Controls the sampling of windows during validation.
+    """
+
+    @validated()
+    def __init__(
+        self,
+        prediction_length: int,
+        context_length: Optional[int] = None,
+        input_size: int = 1,
+        n_layer: int = 1,
+        n_embd: int = 32,
+        n_head: int = 4,
+        dsf_marginal: Dict[str, Any] = {},
+        scaling: Optional[str] = "mean",
+        lr: float = 1e-3,
+        weight_decay: float = 1e-8,
+        aug_prob: float = 0.1,
+        aug_rate: float = 0.1,
+        loss: DistributionLoss = NegativeLogLikelihood(),
+        num_parallel_samples: int = 100,
+        batch_size: int = 32,
+        num_batches_per_epoch: int = 50,
+        trainer_kwargs: Optional[Dict[str, Any]] = None,
+        train_sampler: Optional[InstanceSampler] = None,
+        validation_sampler: Optional[InstanceSampler] = None,
+        ckpt_path: Optional[str] = None,
+    ) -> None:
+        default_trainer_kwargs = {"max_epochs": 100}
+        if trainer_kwargs is not None:
+            default_trainer_kwargs.update(trainer_kwargs)
+        super().__init__(trainer_kwargs=default_trainer_kwargs)
+
+        self.scaling = scaling
+        self.input_size = input_size
+        self.prediction_length = prediction_length
+        self.context_length = context_length or 10 * prediction_length
+
+        self.n_head = n_head
+        self.n_layer = n_layer
+        self.n_embd = n_embd
+        self.dsf_marginal = dsf_marginal
+
+        self.lr = lr
+        self.weight_decay = weight_decay
+        self.num_parallel_samples = num_parallel_samples
+        self.loss = loss
+        self.batch_size = batch_size
+        self.num_batches_per_epoch = num_batches_per_epoch
+
+        self.train_sampler = train_sampler or ExpectedNumInstanceSampler(
+            num_instances=1.0, min_future=prediction_length
+        )
+        self.validation_sampler = validation_sampler or ValidationSplitSampler(
+            min_future=prediction_length
+        )
+
+        self.aug_prob = aug_prob
+        self.aug_rate = aug_rate
+
+        self.ckpt_path = ckpt_path
+
+    @classmethod
+    def derive_auto_fields(cls, train_iter):
+        stats = calculate_dataset_statistics(train_iter)
+
+        return {
+            "num_feat_dynamic_real": stats.num_feat_dynamic_real,
+            "num_feat_static_cat": len(stats.feat_static_cat),
+            "cardinality": [len(cats) for cats in stats.feat_static_cat],
+        }
+
+    def create_transformation(self) -> Transformation:
+        return Chain(
+            [
+                # FilterTransformation(lambda x: sum(abs(x[FieldName.TARGET])) > 0),
+                AddObservedValuesIndicator(
+                    target_field=FieldName.TARGET,
+                    output_field=FieldName.OBSERVED_VALUES,
+                    imputation_method=DummyValueImputation(0.0),
+                ),
+            ]
+        )
+
+    def create_lightning_module(self) -> pl.LightningModule:
+        model_kwargs = {
+            "input_size": self.input_size,
+            "prediction_length": self.prediction_length,
+            "context_length": self.context_length,
+            "n_layer": self.n_layer,
+            "n_embd": self.n_embd,
+            "n_head": self.n_head,
+            "scaling": self.scaling,
+            "dsf_marginal": self.dsf_marginal,
+            "num_parallel_samples": self.num_parallel_samples,
+        }
+        if self.ckpt_path is not None:
+            return LagGPTFlowsLightningModule.load_from_checkpoint(
+                checkpoint_path=self.ckpt_path,
+                loss=self.loss,
+                lr=self.lr,
+                weight_decay=self.weight_decay,
+                aug_prob=self.aug_prob,
+                aug_rate=self.aug_rate,
+                model_kwargs=model_kwargs,
+            )
+        else:
+            return LagGPTFlowsLightningModule(
+                loss=self.loss,
+                lr=self.lr,
+                weight_decay=self.weight_decay,
+                aug_prob=self.aug_prob,
+                aug_rate=self.aug_rate,
+                model_kwargs=model_kwargs,
+            )
+
+    def _create_instance_splitter(self, module: LagGPTFlowsLightningModule, mode: str):
+        assert mode in ["training", "validation", "test"]
+
+        instance_sampler = {
+            "training": self.train_sampler,
+            "validation": self.validation_sampler,
+            "test": TestSplitSampler(),
+        }[mode]
+
+        return InstanceSplitter(
+            target_field=FieldName.TARGET,
+            is_pad_field=FieldName.IS_PAD,
+            start_field=FieldName.START,
+            forecast_start_field=FieldName.FORECAST_START,
+            instance_sampler=instance_sampler,
+            past_length=module.model._past_length,
+            future_length=self.prediction_length,
+            time_series_fields=[FieldName.OBSERVED_VALUES],
+            dummy_value=0.,
+        )
+
+    def create_training_data_loader(
+        self,
+        data: Dataset,
+        module: LagGPTFlowsLightningModule,
+        shuffle_buffer_length: Optional[int] = None,
+        **kwargs,
+    ) -> Iterable:
+        data = Cyclic(data).stream()
+        instances = self._create_instance_splitter(module, "training").apply(
+            data, is_train=True
+        )
+        return as_stacked_batches(
+            instances,
+            batch_size=self.batch_size,
+            shuffle_buffer_length=shuffle_buffer_length,
+            field_names=TRAINING_INPUT_NAMES,
+            output_type=torch.tensor,
+            num_batches_per_epoch=self.num_batches_per_epoch,
+        )
+
+    def create_validation_data_loader(
+        self,
+        data: Dataset,
+        module: LagGPTFlowsLightningModule,
+        **kwargs,
+    ) -> Iterable:
+        instances = self._create_instance_splitter(module, "validation").apply(
+            data, is_train=True
+        )
+        return as_stacked_batches(
+            instances,
+            batch_size=self.batch_size,
+            field_names=TRAINING_INPUT_NAMES,
+            output_type=torch.tensor,
+        )
+
+    def create_predictor(
+        self,
+        transformation: Transformation,
+        module,
+    ) -> PyTorchPredictor:
+        prediction_splitter = self._create_instance_splitter(module, "test")
+
+        return PyTorchPredictor(
+            input_transform=transformation + prediction_splitter,
+            input_names=PREDICTION_INPUT_NAMES,
+            prediction_net=module,
+            batch_size=self.batch_size,
+            prediction_length=self.prediction_length,
+            device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        )

--- a/lag-gpt-flows/flow.py
+++ b/lag-gpt-flows/flow.py
@@ -1,0 +1,280 @@
+# MIT License
+
+# Copyright (c) 2019 Chin-Wei Huang
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# Adapted from: https://github.com/CW-Huang/torchkit/blob/master/torchkit/flows.py
+
+import math
+import torch
+from torch import nn
+
+# To be compared to the float32 machine epsilon of 2**-23 ~= 1.2e-7
+EPSILON = 1e-6
+
+
+
+def log_sum_exp(A, dim=-1, keepdim=False):
+    """
+    Compute a sum in logarithm space: log(exp(a) + exp(b))
+    Properly handle values which exponential cannot be represented in float32.
+    """
+    max_A = A.max(axis=dim, keepdim=True).values
+    norm_A = A - max_A
+    result = torch.log(torch.exp(norm_A).sum(axis=dim, keepdim=True)) + max_A
+    if keepdim:
+        return result
+    else:
+        return torch.squeeze(result, dim=dim)
+
+
+def log_sigmoid(x):
+    """
+    Logarithm of the sigmoid function.
+    Substract the epsilon to avoid 0 as a possible value for large x.
+    """
+    return -nn.functional.softplus(-x) - EPSILON
+
+def act_a(x): return nn.functional.softplus(x) + EPSILON
+def act_b(x): return x
+def act_w(x): return nn.functional.softmax(x, dim=-1)
+
+class SigmoidFlow(nn.Module):
+    # Indices:
+    # b: batch
+    # s: sample
+    # o: output dimension
+    # h: hidden dimension
+    # i: input dimension
+
+    def __init__(self, hidden_dim: int, no_logit: bool = False):
+        """
+        A single layer of the Deep Sigmoid Flow network.
+        Does not contains its parameters, they must be sent in the forward method.
+
+        Parameters:
+        -----------
+        hidden_dim: uint
+            The number of hidden units
+        no_logit: bool, default to False
+            If set to True, then the network will return a value in the (0, 1) interval.
+            If kept to False, then the network will apply a logit function to this value to return
+            a value in the (-inf, inf) interval.
+        """
+        super(SigmoidFlow, self).__init__()
+        self.hidden_dim = hidden_dim
+        self.no_logit = no_logit
+
+        self.act_a = act_a
+        self.act_b = act_b
+        self.act_w = act_w
+
+    def forward(self, params, x, logdet):
+        """
+        Transform the given value according to the given parameters,
+        computing the derivative of the transformation at the same time.
+        params third dimension must be equal to 3 times the number of hidden units.
+        """
+        # Indices:
+        # b: batch
+        # v: variables
+        # h: hidden dimension
+
+        # params: b, v, 3*h
+        # x: b, v
+        # logdet: b
+        # output x: b, v
+        # output logdet: b
+        assert params.shape[-1] == 3 * self.hidden_dim
+
+        a = self.act_a(params[..., : self.hidden_dim])  # b, v, h
+        b = self.act_b(params[..., self.hidden_dim : 2 * self.hidden_dim])  # b, v, h
+        pre_w = params[..., 2 * self.hidden_dim :]  # b, v, h
+        w = self.act_w(pre_w)  # b, v, h
+
+        pre_sigm = a * x[..., None] + b  # b, v, h
+        sigm = torch.sigmoid(pre_sigm)  # b, v, h
+        x_pre = (w * sigm).sum(dim=-1)  # b, v
+
+        logj = (
+            nn.functional.log_softmax(pre_w, dim=-1) + log_sigmoid(pre_sigm) + log_sigmoid(-pre_sigm) + torch.log(a)
+        )  # b, v, h
+
+        logj = log_sum_exp(logj, dim=-1, keepdim=False)  # b, v
+
+        if self.no_logit:
+            # Only keep the batch dimension, summing all others in case this method is called with more dimensions
+            # Adding the passed logdet here to accumulate 
+            logdet = logj.sum(dim=tuple(range(1, logj.dim()))) + logdet
+            return x_pre, logdet
+
+        x_pre_clipped = x_pre * (1 - EPSILON) + EPSILON * 0.5  # b, v
+        xnew = torch.log(x_pre_clipped) - torch.log(1 - x_pre_clipped)  # b, v
+
+        logdet_ = logj + math.log(1 - EPSILON) - (torch.log(x_pre_clipped) + torch.log(-x_pre_clipped + 1))  # b, v
+
+        # Only keep the batch dimension, summing all others in case this method is called with more dimensions
+        logdet = logdet_.sum(dim=tuple(range(1, logdet_.dim()))) + logdet
+
+        return xnew, logdet
+
+    def forward_no_logdet(self, params, x):
+        """
+        Transform the given value according to the given parameters,
+        but does not compute the derivative of the transformation.
+        params third dimension must be equal to 3 times the number of hidden units.
+        """
+        # Indices: (when used for inversion)
+        # b: batch
+        # s: samples
+        # h: hidden dimension
+
+        # params: b, s, 3*h
+        # x: b, s
+        # output x: b, s
+        assert params.shape[-1] == 3 * self.hidden_dim
+
+        a = self.act_a(params[..., : self.hidden_dim])  # b, s, h
+        b = self.act_b(params[..., self.hidden_dim : 2 * self.hidden_dim])  # b, s, h
+        pre_w = params[..., 2 * self.hidden_dim :]  # b, s, h
+        w = self.act_w(pre_w)  # b, s, h
+
+        pre_sigm = a * x[..., None] + b  # b, s, h
+        sigm = torch.sigmoid(pre_sigm)  # b, s, h
+        x_pre = (w * sigm).sum(dim=-1)  # b, s
+
+        if self.no_logit:
+            return x_pre
+
+        x_pre_clipped = x_pre * (1 - EPSILON) + EPSILON * 0.5  # b, s
+        xnew = torch.log(x_pre_clipped) - torch.log(1 - x_pre_clipped)  # b, s
+
+        return xnew
+
+
+class DeepSigmoidFlow(nn.Module):
+    def __init__(self, n_layers: int, hidden_dim: int):
+        """
+        A Deep Sigmoid Flow network, made of multiple Sigmoig Flow layers.
+        This model a flexible transformation from any real values into the (0, 1) interval.
+        Does not contains its parameters, they must be sent in the forward method.
+
+        Parameters:
+        -----------
+        n_layers: uint
+            The number of sigmoid flow layers
+        hidden_dim: uint
+            The number of hidden units
+        """
+        super(DeepSigmoidFlow, self).__init__()
+
+        self.params_length = 3 * hidden_dim
+
+        elayers = nn.ModuleList([SigmoidFlow(hidden_dim) for _ in range(n_layers - 1)])
+        elayers += [SigmoidFlow(hidden_dim, no_logit=True)]
+        self.layers = nn.Sequential(*elayers)
+
+    @property
+    def total_params_length(self):
+        return len(self.layers) * self.params_length
+
+    def forward(self, params, x):
+        """
+        Transform the given value according to the given parameters,
+        computing the derivative of the transformation at the same time.
+        params third dimension must be equal to total_params_length.
+        """
+        # params: batches, variables, params dim
+        # x: batches, variables
+        logdet = torch.zeros(
+            x.shape[0],
+        ).to(x.device)
+        for i, layer in enumerate(self.layers):
+            x, logdet = layer(params[..., i * self.params_length : (i + 1) * self.params_length], x, logdet)
+        return x, logdet
+
+    def forward_no_logdet(self, params, x):
+        """
+        Transform the given value according to the given parameters,
+        but does not compute the derivative of the transformation.
+        params third dimension must be equal to total_params_length.
+        """
+        # params: batches, samples, params dim
+        # x: batches, samples
+        for i, layer in enumerate(self.layers):
+            x = layer.forward_no_logdet(params[..., i * self.params_length : (i + 1) * self.params_length], x)
+        return x
+
+    def inverse(
+        self,
+        marginal_params: torch.Tensor,
+        u: torch.Tensor,
+        max_iter: int = 100,
+        precision: float = 1e-6,
+        max_value: float = 1000.0,
+    ) -> torch.Tensor:
+        """
+
+        NOTE: Added for compatability with Alex' notebook "ground_truth_copula.ipynb" demonstrating the 2-dimensional example
+        This function actually belongs to the "marginal" class
+
+        Compute the inverse cumulative density function of a marginal conditioned using the given context, for the given value of u.
+        This method uses a dichotomic search.
+        The gradient of this method cannot be computed, so it should only be used for sampling.
+
+        Parameters:
+        -----------
+        context: Tensor [batch, series * time steps, embedding dimension]
+            A tensor containing an embedding for each variable and time step.
+            The series and time steps dimensions are merged.
+        u: Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            A tensor containing the value to be transformed using the inverse CDF.
+            The series and time steps dimensions are merged.
+            If a third dimension is present, then the context is considered to be constant across this dimension.
+        max_iter: int, default = 100
+            The maximum number of iterations for the dichotomic search.
+            The precision of the result should improve by a factor of 2 at each iteration.
+        precision: float, default = 1e-6
+            If the difference between CDF(x) and u is less than this value for all variables, stop the search.
+        max_value: float, default = 1000.0
+            The absolute upper bound on the possible output.
+        Returns:
+        --------
+        x: torch.Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            The inverse CDF at the given value.
+            The series and time steps dimensions are merged.
+            The shape of the output is the same as the shape of u.
+        """
+        # If u has both a variable and a sample dimension, then add a singleton dimension to marginal_params to have the correct shape
+        if marginal_params.dim() == u.dim():
+            marginal_params = marginal_params[:, :, None, :]
+
+        left = -max_value * torch.ones_like(u)
+        right = max_value * torch.ones_like(u)
+        for _ in range(max_iter):
+            mid = (left + right) / 2
+            error = self.forward_no_logdet(marginal_params, mid) - u
+            left[error <= 0] = mid[error <= 0]
+            right[error >= 0] = mid[error >= 0]
+
+            max_error = error.abs().max().item()
+            if max_error < precision:
+                break
+        return mid

--- a/lag-gpt-flows/lag-gpt-flows-scaling-data.py
+++ b/lag-gpt-flows/lag-gpt-flows-scaling-data.py
@@ -1,0 +1,152 @@
+import random
+from pathlib import Path
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from gluonts.evaluation import make_evaluation_predictions, Evaluator
+from gluonts.dataset.repository.datasets import get_dataset
+from pytorch_lightning.loggers import CSVLogger, WandbLogger
+
+from estimator import LagGPTFlowsEstimator
+from pathlib import Path
+
+import argparse
+import yaml
+
+import os
+import pathlib
+import pytorch_lightning as pl
+
+parser = argparse.ArgumentParser()
+parser.add_argument("filename", help = "YAML config file.")
+parser.add_argument("--suffix", default="", type=str, required=True, help="This can be useful information to distinguish runs, like `heads-scaling-5-heads`")
+parser.add_argument("--seed", default=42, type=int)
+parser.add_argument("--dataset_path", default="/home/toolkit/datasets", type=str)
+parser.add_argument("--precision", default="32", type=str, choices=["32", "16", "bf16-mixed"])
+args = parser.parse_args()
+
+
+with open(args.filename, mode="rt", encoding="utf-8") as file:
+    config = yaml.safe_load(file)
+
+pl.seed_everything(args.seed)
+
+class CombinedDatasetIterator:
+    def __init__(self, datasets, seed, weights):
+        self._datasets = [iter(el) for el in datasets]
+        self._weights = weights
+        self._rng = random.Random(seed)
+
+    def __next__(self):
+        (dataset,) = self._rng.choices(self._datasets, weights=self._weights, k=1)
+        return next(dataset)
+
+class CombinedDataset:
+    def __init__(self, datasets, seed=None, weights=None):
+        self._seed = seed
+        self._datasets = datasets
+        self._weights = weights
+        n_datasets = len(datasets)
+        if weights is None:
+            self._weights = [1 / n_datasets] * n_datasets
+
+    def __iter__(self):
+        return CombinedDatasetIterator(self._datasets, self._seed, self._weights)
+    
+    def __len__(self):
+        return sum([len(ds) for ds in self._datasets])
+
+print("Loading data...")
+dataset_path = Path(args.dataset_path)
+gluonts_ds = [
+        get_dataset("airpassengers", path=dataset_path).train,
+        get_dataset("australian_electricity_demand", path=dataset_path).train,
+        get_dataset("car_parts_without_missing", path=dataset_path).train,
+        get_dataset("cif_2016", path=dataset_path).train,
+        get_dataset("covid_deaths", path=dataset_path).train,
+        get_dataset("electricity", path=dataset_path).train,
+        get_dataset("electricity_weekly", path=dataset_path).train,
+        get_dataset("exchange_rate", path=dataset_path).train,
+        get_dataset("fred_md", path=dataset_path).train,
+        get_dataset("hospital", path=dataset_path).train,
+        get_dataset("kaggle_web_traffic_weekly", path=dataset_path).train,
+        get_dataset("kdd_cup_2018_without_missing", path=dataset_path).train,
+        get_dataset("london_smart_meters_without_missing", path=dataset_path).train,
+        get_dataset("nn5_daily_with_missing", path=dataset_path).train,
+        get_dataset("nn5_weekly", path=dataset_path).train,
+        get_dataset("pedestrian_counts", path=dataset_path).train,
+        get_dataset("rideshare_without_missing", path=dataset_path).train,
+        get_dataset("saugeenday", path=dataset_path).train,
+        get_dataset("solar-energy", path=dataset_path).train,
+        get_dataset("solar_10_minutes", path=dataset_path).train,
+        get_dataset("solar_weekly", path=dataset_path).train,
+        get_dataset("taxi_30min", path=dataset_path).train,
+        get_dataset("temperature_rain_without_missing", path=dataset_path).train,
+        get_dataset("tourism_monthly", path=dataset_path).train,
+        get_dataset("uber_tlc_daily", path=dataset_path).train,
+        get_dataset("uber_tlc_hourly", path=dataset_path).train,
+        get_dataset("vehicle_trips_without_missing", path=dataset_path).train,
+        get_dataset("weather", path=dataset_path).train,
+        get_dataset("wiki-rolling_nips", path=dataset_path).train,
+        get_dataset("m4_daily", path=dataset_path).train,
+        get_dataset("m4_hourly", path=dataset_path).train,
+        get_dataset("m4_monthly", path=dataset_path).train,
+        get_dataset("m4_quarterly", path=dataset_path).train,
+        get_dataset("m4_yearly", path=dataset_path).train,
+        get_dataset("wind_farms_without_missing", path=dataset_path).train,
+]
+dataset = CombinedDataset(gluonts_ds, weights=([sum([len(x["target"]) for x in d]) for d in gluonts_ds] if config["dataset"]["weighted"] else None), seed=args.seed) 
+
+val_dataset = get_dataset(config["dataset"]["val"], path=dataset_path).test
+meta = get_dataset(config["dataset"]["val"], path=dataset_path).metadata
+
+experiment_name = ("data-scaling-weighted-"+str(config["gpt"]["aug_prob"])+"_"+args.suffix if config["dataset"]["weighted"] else "data-scaling-uniform-"+str(config["gpt"]["aug_prob"])+"_"+args.suffix)
+fulldir = os.path.join(pathlib.Path(__file__).parent.resolve(), "scaling-logs", experiment_name, str(args.seed)) # Always creates the experiment directory inside "lag-gpt-flows"
+os.makedirs(fulldir, exist_ok=True)
+experiment_logger = CSVLogger(save_dir=fulldir, flush_logs_every_n_steps=config["metrics"]["num_steps"]) if config["metrics"]["logger"]=="csv" else WandbLogger(name=experiment_name + "/" + args.seed, group=experiment_name, save_dir=fulldir, config=config)
+experiment_version = experiment_logger.version # Should be 1 always since we create a new experiment for each seed
+print("Experiment directory:", fulldir)
+
+estimator = LagGPTFlowsEstimator(
+    prediction_length=meta.prediction_length,
+    context_length=config["gpt"]["context_length"], # block_size: int = 2048 
+    batch_size=config["gpt"]["batch_size"], # 4
+    n_layer=config["gpt"]["n_layer"],
+    n_head=config["gpt"]["n_head"],
+    n_embd=config["gpt"]["n_embd"], # 4096
+    dsf_marginal=config["gpt"]["dsf_marginal"],
+    scaling=config["gpt"]["scaling"],
+    aug_prob = config["gpt"]["aug_prob"],
+    aug_rate = config["gpt"]["aug_rate"],
+    num_batches_per_epoch= config["gpt"]["batches_per_epoch"],
+    trainer_kwargs=dict(max_epochs=config["gpt"]["max_epochs"], log_every_n_steps = config["metrics"]["num_steps"], val_check_interval=config["metrics"]["num_steps"], accelerator="gpu", precision="32", logger=experiment_logger, devices=[config["CUDA"]["device_id"]]),
+)
+
+
+predictor = estimator.train(
+    training_data=dataset, 
+    validation_data=val_dataset,
+    shuffle_buffer_length=1000
+)
+
+if config["metrics"]["logger"]=="csv":
+    loss_df = pd.read_csv(fulldir+"/lightning_logs/version_"+str(experiment_version)+"/metrics.csv")
+    train_loss = loss_df.dropna(subset=["train_loss"])
+    val_loss = loss_df.dropna(subset=["val_loss"])
+
+    fig, ax = plt.subplots()
+    ax.plot(train_loss["step"], train_loss["train_loss"])
+    ax.set_xscale("log")
+    ax.set_ylabel("Training Loss")
+    ax.set_xlabel("Steps")
+    fig.savefig(fulldir+"/lightning_logs/version_"+str(experiment_version)+"/train_loss.png") 
+    plt.close(fig)
+
+    fig, ax = plt.subplots()
+    ax.plot(val_loss["step"], val_loss["val_loss"])
+    ax.set_xscale("log")
+    ax.set_ylabel("Validation Loss")
+    ax.set_xlabel("Steps")
+    fig.savefig(fulldir+"/lightning_logs/version_"+str(experiment_version)+"/val_loss.png") 
+    plt.close(fig)
+

--- a/lag-gpt-flows/lag-gpt-flows-scaling-data.py
+++ b/lag-gpt-flows/lag-gpt-flows-scaling-data.py
@@ -129,7 +129,7 @@ predictor = estimator.train(
     shuffle_buffer_length=1000
 )
 
-if config["metrics"]["logger"]=="csv":
+if "metrics" in config and config["metrics"]["logger"]=="csv":
     loss_df = pd.read_csv(fulldir+"/lightning_logs/version_"+str(experiment_version)+"/metrics.csv")
     train_loss = loss_df.dropna(subset=["train_loss"])
     val_loss = loss_df.dropna(subset=["val_loss"])

--- a/lag-gpt-flows/lightning_module.py
+++ b/lag-gpt-flows/lightning_module.py
@@ -1,0 +1,172 @@
+import random
+
+import pytorch_lightning as pl
+import torch
+
+from gluonts.core.component import validated
+from gluonts.torch.modules.loss import DistributionLoss, NegativeLogLikelihood
+from gluonts.torch.util import take_last, repeat_along_dim
+from gluonts.itertools import prod
+
+from module import LagGPTFlowsModel
+from aug import freq_mask, freq_mix
+
+
+class LagGPTFlowsLightningModule(pl.LightningModule):
+    """
+    A ``pl.LightningModule`` class that can be used to train a
+    ``LagGPTLightningModule`` with PyTorch Lightning.
+
+    This is a thin layer around a (wrapped) ``LagGPTLightningModule`` object,
+    that exposes the methods to evaluate training and validation loss.
+
+    Parameters
+    ----------
+    model
+        ``LagGPTLightningModule`` to be trained.
+    loss
+        Loss function to be used for training,
+        default: ``NegativeLogLikelihood()``.
+    lr
+        Learning rate, default: ``1e-3``.
+    weight_decay
+        Weight decay regularization parameter, default: ``1e-8``.
+    """
+
+    @validated()
+    def __init__(
+        self,
+        model_kwargs: dict,
+        loss: DistributionLoss = NegativeLogLikelihood(),
+        lr: float = 1e-3,
+        weight_decay: float = 1e-8,
+        aug_prob: float = 0.1,
+        aug_rate: float = 0.1,
+    ):
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = LagGPTFlowsModel(**self.hparams.model_kwargs)
+        self.loss = self.hparams.loss
+        self.lr = self.hparams.lr
+        self.weight_decay = self.hparams.weight_decay
+        self.aug_prob = self.hparams.aug_prob
+        self.aug_rate = self.hparams.aug_rate
+
+    # mean prediction and then sample
+    def forward(self, *args, **kwargs):
+        past_target = kwargs["past_target"]
+        past_observed_values = kwargs["past_observed_values"]
+        samples = torch.zeros(past_target.shape[0], self.model.prediction_length, self.model.num_parallel_samples).to(past_target.device)
+
+        for t in range(self.model.prediction_length):
+            transformer_output, scaled_input, loc, scale = self.model(
+                *args,
+                past_target=past_target,
+                past_observed_values=past_observed_values,
+            )
+            # Get the encoding of the last timestep predicted so far
+            pred_encoding = transformer_output[:, -1:] # Shape: [bsz, 1, dims]
+            # Construct uniform random samples
+            pred_samples = torch.rand(pred_encoding.shape[0], 1, self.model.num_parallel_samples, device=pred_encoding.device)
+            # Transform to [min_u, max_u]
+            pred_samples = self.model.min_u + (self.model.max_u - self.model.min_u) * pred_samples
+            # Transform to the distribution of each token
+            # Pass the encoding of the last token and predict the distribution of the next token
+            pred_samples = self.model.marginal.inverse(
+                pred_encoding,
+                pred_samples
+            ) # Shape: [bsz, 1, num_parallel_samples]
+            # Renormalize the samples
+            pred_samples = pred_samples * scale.unsqueeze(2) + loc.unsqueeze(2)
+            samples[:, t] = pred_samples.squeeze(1)
+
+            past_target = torch.cat((past_target, pred_samples.mean(-1)), dim=1)
+            past_observed_values = torch.cat(
+                (past_observed_values, torch.ones_like(pred_samples.mean(-1))), dim=1
+            )
+
+        return samples
+
+    # train
+    def _compute_loss(self, batch):
+        past_target = batch["past_target"] # (bsz, model._past_length)
+        past_observed_values = batch["past_observed_values"] # (bsz, model._past_length)
+        future_target = batch["future_target"] # (bsz, model.prediction_length)
+        future_observed_values = batch["future_observed_values"] # (bsz, model.prediction_length)
+
+        extra_dims = len(future_target.shape) - len(past_target.shape) # usually 0
+        extra_shape = future_target.shape[:extra_dims]
+
+        repeats = prod(extra_shape)
+        past_target = repeat_along_dim(past_target, 0, repeats) # (bsz, model._past_length)
+        past_observed_values = repeat_along_dim(past_observed_values, 0, repeats) # (bsz, model._past_length)
+
+        future_target_reshaped = future_target.reshape(
+            -1,
+            *future_target.shape[extra_dims + 1 :],
+        ) # (bsz, model.prediction_length)
+        future_observed_reshaped = future_observed_values.reshape(
+            -1,
+            *future_observed_values.shape[extra_dims + 1 :],
+        ) # (bsz, model.prediction_length)
+
+        transformer_output, scaled_input, loc, scale = self.model(
+            past_target=past_target,
+            past_observed_values=past_observed_values,
+            future_target=future_target_reshaped,
+        ) # (bsz, )
+
+        # TODO: We can also possibly use the history tokens in the objective since they are causally masked here?
+        # NOTE: This is a decoder-only model 
+        # So we train the normalizing flows to predict the marginals of the next token here 
+        # The encoding given to the normalizing flow is the encoding of the kth token
+        # NOTE: Maybe use prediction_length 
+        # pred_encoding = transformer_output[:, -self.model.prediction_length:-1]
+        pred_encoding = transformer_output[:, self.model.context_length:-1]
+        pred_scaled_input = scaled_input[:, self.model.context_length+1:]
+
+        pred_u, pred_logdet = self.model.marginal.forward_logdet(pred_encoding, pred_scaled_input) # (BSZ, )
+
+        return -pred_logdet.sum() / pred_logdet.shape[0]
+
+    def training_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute training step.
+        """
+        if random.random() < self.aug_prob:
+            if random.random() < 0.5:
+                batch["past_target"], batch["future_target"] = freq_mask(
+                    batch["past_target"], batch["future_target"], rate=self.aug_rate
+                )
+            else:
+                batch["past_target"], batch["future_target"] = freq_mix(
+                    batch["past_target"], batch["future_target"], rate=self.aug_rate
+                )
+
+        train_loss = self._compute_loss(batch)
+        self.log(
+            "train_loss",
+            train_loss,
+            on_epoch=True,
+            on_step=False,
+            prog_bar=True,
+        )
+        return train_loss
+
+    def validation_step(self, batch, batch_idx: int):  # type: ignore
+        """
+        Execute validation step.
+        """
+        val_loss = self._compute_loss(batch)
+        self.log("val_loss", val_loss, on_epoch=True, on_step=False, prog_bar=True)
+        return val_loss
+
+    def configure_optimizers(self):
+        """
+        Returns the optimizer to use.
+        """
+        return torch.optim.Adam(
+            self.model.parameters(),
+            lr=self.lr,
+            weight_decay=self.weight_decay,
+        )

--- a/lag-gpt-flows/marginal.py
+++ b/lag-gpt-flows/marginal.py
@@ -1,0 +1,170 @@
+"""
+Copyright 2022 ServiceNow
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>> The marginal distribution for the forecasts
+"""
+
+
+import torch
+from torch import nn
+from typing import Tuple
+from flow import DeepSigmoidFlow
+
+class DSFMarginal(nn.Module):
+    """
+    Compute the marginals using a Deep Sigmoid Flow conditioned using a MLP.
+    The conditioning MLP uses the embedding from the encoder as its input.
+    """
+
+    def __init__(self, context_dim: int, mlp_layers: int, mlp_dim: int, flow_layers: int, flow_hid_dim: int):
+        """
+        Parameters:
+        -----------
+        context_dim: int
+            Size of the context (embedding created by the encoder) that will be sent to the conditioner.
+        mlp_layers: int
+            Number of layers for the conditioner MLP.
+        mlp_dim: int
+            Dimension of the hidden layers of the conditioner MLP.
+        flow_layers: int
+            Number of layers for the Dense Sigmoid Flow.
+        flow_hid_dim: int
+            Dimension of the hidden layers of the Dense Sigmoid Flow.
+        """
+        super().__init__()
+
+        self.context_dim = context_dim
+        self.mlp_layers = mlp_layers
+        self.mlp_dim = mlp_dim
+        self.flow_layers = flow_layers
+        self.flow_hid_dim = flow_hid_dim
+
+        self.marginal_flow = DeepSigmoidFlow(n_layers=self.flow_layers, hidden_dim=self.flow_hid_dim)
+
+        elayers = [nn.Linear(self.context_dim, self.mlp_dim), nn.ReLU()]
+        for _ in range(1, self.mlp_layers):
+            elayers += [nn.Linear(self.mlp_dim, self.mlp_dim), nn.ReLU()]
+        elayers += [nn.Linear(self.mlp_dim, self.marginal_flow.total_params_length)]
+        self.marginal_conditioner = nn.Sequential(*elayers)
+
+    def forward_logdet(self, context: torch.Tensor, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Compute the cumulative density function of a marginal conditioned using the given context, for the given value of x.
+        Also returns the logarithm of the derivative of this transformation.
+
+        Parameters:
+        -----------
+        context: Tensor [batch, series * time steps, embedding dimension]
+            A tensor containing an embedding for each variable and time step.
+            The series and time steps dimensions are merged.
+        x: Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            A tensor containing the value to be transformed using the CDF.
+            The series and time steps dimensions are merged.
+            If a third dimension is present, then the context is considered to be constant across this dimension.
+        Returns:
+        --------
+        u: torch.Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            The CDF at the given point, a value between 0 and 1.
+            The series and time steps dimensions are merged.
+            The shape of the output is the same as the shape of x.
+        logdet: torch.Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            The logarithm of the derivative of the transformation.
+            The series and time steps dimensions are merged.
+            The shape of the output is the same as the shape of x.
+        """
+        marginal_params = self.marginal_conditioner(context)
+        # If x has both a variable and a sample dimension, then add a singleton dimension to marginal_params to have the correct shape
+        if marginal_params.dim() == x.dim():
+            marginal_params = marginal_params[:, :, None, :]
+
+        return self.marginal_flow.forward(marginal_params, x)
+
+    def forward_no_logdet(self, context: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+        """
+        Compute the cumulative density function of a marginal conditioned using the given context, for the given value of x.
+
+        Parameters:
+        -----------
+        context: Tensor [batch, series * time steps, embedding dimension]
+            A tensor containing an embedding for each variable and time step.
+            The series and time steps dimensions are merged.
+        x: Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            A tensor containing the value to be transformed using the CDF.
+            The series and time steps dimensions are merged.
+            If a third dimension is present, then the context is considered to be constant across this dimension.
+        Returns:
+        --------
+        u: torch.Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            The CDF at the given point, a value between 0 and 1.
+            The series and time steps dimensions are merged.
+            The shape of the output is the same as the shape of x.
+        """
+        marginal_params = self.marginal_conditioner(context) # [batch, series*timesteps, self.marginal_flow.total_params_length]
+        # If x has both a variable and a sample dimension, then add a singleton dimension to marginal_params to have the correct shape
+        if marginal_params.dim() == x.dim():
+            marginal_params = marginal_params[:, :, None, :]
+
+        return self.marginal_flow.forward_no_logdet(marginal_params, x)
+
+    def inverse(
+        self,
+        context: torch.Tensor,
+        u: torch.Tensor,
+        max_iter: int = 100,
+        precision: float = 1e-6,
+        max_value: float = 1000.0,
+    ) -> torch.Tensor:
+        """
+        Compute the inverse cumulative density function of a marginal conditioned using the given context, for the given value of u.
+        This method uses a dichotomic search.
+        The gradient of this method cannot be computed, so it should only be used for sampling.
+
+        Parameters:
+        -----------
+        context: Tensor [batch, series * time steps, embedding dimension]
+            A tensor containing an embedding for each variable and time step.
+            The series and time steps dimensions are merged.
+        u: Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            A tensor containing the value to be transformed using the inverse CDF.
+            The series and time steps dimensions are merged.
+            If a third dimension is present, then the context is considered to be constant across this dimension.
+        max_iter: int, default = 100
+            The maximum number of iterations for the dichotomic search.
+            The precision of the result should improve by a factor of 2 at each iteration.
+        precision: float, default = 1e-6
+            If the difference between CDF(x) and u is less than this value for all variables, stop the search.
+        max_value: float, default = 1000.0
+            The absolute upper bound on the possible output.
+        Returns:
+        --------
+        x: torch.Tensor [batch, series * time steps] or [batch, series * time steps, samples]
+            The inverse CDF at the given value.
+            The series and time steps dimensions are merged.
+            The shape of the output is the same as the shape of u.
+        """
+        marginal_params = self.marginal_conditioner(context)
+        # If u has both a variable and a sample dimension, then add a singleton dimension to marginal_params to have the correct shape
+        if marginal_params.dim() == u.dim():
+            marginal_params = marginal_params[:, :, None, :]
+
+        left = -max_value * torch.ones_like(u)
+        right = max_value * torch.ones_like(u)
+        for _ in range(max_iter):
+            mid = (left + right) / 2
+            error = self.marginal_flow.forward_no_logdet(marginal_params, mid) - u
+            left[error <= 0] = mid[error <= 0]
+            right[error >= 0] = mid[error >= 0]
+
+            max_error = error.abs().max().item()
+            if max_error < precision:
+                break
+        return mid

--- a/lag-gpt-flows/module.py
+++ b/lag-gpt-flows/module.py
@@ -1,0 +1,330 @@
+from typing import Optional
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple, Type
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from gluonts.time_feature import get_lags_for_frequency
+from gluonts.torch.util import lagged_sequence_values, unsqueeze_expand
+from gluonts.torch.scaler import StdScaler, MeanScaler, NOPScaler
+from gluonts.torch.distributions import StudentTOutput
+
+from marginal import DSFMarginal
+
+llama_configs = {
+    "7B": dict(n_layer=32, n_head=32, n_embd=2048),
+    "13B": dict(n_layer=40, n_head=40, n_embd=5120),
+    "30B": dict(n_layer=60, n_head=52, n_embd=6656),
+    "65B": dict(n_layer=80, n_head=64, n_embd=8192),
+}
+
+
+@dataclass
+class LTSMConfig:
+    feature_size: int = 3 + 6  # target + loc + scale + time features
+    block_size: int = 2048
+    n_layer: int = 32
+    n_head: int = 32
+    n_embd: int = 4096
+
+
+class Block(nn.Module):
+    def __init__(self, config: LTSMConfig) -> None:
+        super().__init__()
+        self.rms_1 = RMSNorm(config.n_embd)
+        self.attn = CausalSelfAttention(config)
+        self.rms_2 = RMSNorm(config.n_embd)
+        self.mlp = MLP(config)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x + self.attn(self.rms_1(x))
+        x = x + self.mlp(self.rms_2(x))
+        return x
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, config: LTSMConfig) -> None:
+        super().__init__()
+        assert config.n_embd % config.n_head == 0
+
+        # key, query, value projections for all heads, but in a batch
+        self.c_attn = nn.Linear(config.n_embd, 3 * config.n_embd, bias=False)
+        # output projection
+        self.c_proj = nn.Linear(config.n_embd, config.n_embd, bias=False)
+
+        self.n_head = config.n_head
+        self.n_embd = config.n_embd
+        self.block_size = config.block_size
+        self.rope_cache: Optional[torch.Tensor] = None
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # batch size, sequence length, embedding dimensionality (n_embd)
+        (B, T, C) = x.size()
+
+        # calculate query, key, values for all heads in batch and move head forward to be the batch dim
+        q, k, v = self.c_attn(x).split(self.n_embd, dim=2)
+
+        head_size = C // self.n_head
+        k = k.view(B, T, self.n_head, head_size).transpose(1, 2)  # (B, nh, T, hs)
+        q = q.view(B, T, self.n_head, head_size).transpose(1, 2)  # (B, nh, T, hs)
+        v = v.view(B, T, self.n_head, head_size).transpose(1, 2)  # (B, nh, T, hs)
+
+        if self.rope_cache is None:
+            # cache for future forward calls
+            self.rope_cache = build_rope_cache(
+                seq_len=self.block_size,
+                n_elem=self.n_embd // self.n_head,
+                dtype=x.dtype,
+                device=x.device,
+            )
+
+        q = apply_rope(q, self.rope_cache)
+        k = apply_rope(k, self.rope_cache)
+
+        # causal self-attention; Self-attend: (B, nh, T, hs) x (B, nh, hs, T) -> (B, nh, T, T)
+        #  att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+        #  att = att.masked_fill(self.bias[:,:,:T,:T] == 0, float('-inf'))
+        #  att = F.softmax(att, dim=-1)
+        #  y = att @ v # (B, nh, T, T) x (B, nh, T, hs) -> (B, nh, T, hs)
+
+        # efficient attention using Flash Attention CUDA kernels
+        y = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=None, dropout_p=0.0, is_causal=True
+        )
+
+        y = (
+            y.transpose(1, 2).contiguous().view(B, T, C)
+        )  # re-assemble all head outputs side by side
+
+        # output projection
+        y = self.c_proj(y)
+
+        return y
+
+
+def find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+class MLP(nn.Module):
+    def __init__(self, config: LTSMConfig) -> None:
+        super().__init__()
+        hidden_dim = 4 * config.n_embd
+        n_hidden = int(2 * hidden_dim / 3)
+        n_hidden = find_multiple(n_hidden, 256)
+
+        self.c_fc1 = nn.Linear(config.n_embd, n_hidden, bias=False)
+        self.c_fc2 = nn.Linear(config.n_embd, n_hidden, bias=False)
+        self.c_proj = nn.Linear(n_hidden, config.n_embd, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = F.silu(self.c_fc1(x)) * self.c_fc2(x)
+        x = self.c_proj(x)
+        return x
+
+
+class RMSNorm(nn.Module):
+    """Root Mean Square Layer Normalization.
+
+    Derived from https://github.com/bzhangGo/rmsnorm/blob/master/rmsnorm_torch.py. BSD 3-Clause License:
+    https://github.com/bzhangGo/rmsnorm/blob/master/LICENSE.
+    """
+
+    def __init__(self, size: int, dim: int = -1, eps: float = 1e-5) -> None:
+        super().__init__()
+        self.scale = nn.Parameter(torch.ones(size))
+        self.eps = eps
+        self.dim = dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # NOTE: the original RMSNorm paper implementation is not equivalent
+        # norm_x = x.norm(2, dim=self.dim, keepdim=True)
+        # rms_x = norm_x * d_x ** (-1. / 2)
+        # x_normed = x / (rms_x + self.eps)
+        # keep RMSNorm in float32
+        norm_x = x.to(torch.float32).pow(2).mean(dim=self.dim, keepdim=True)
+        x_normed = x * torch.rsqrt(norm_x + self.eps)
+        return (self.scale * x_normed).type_as(x)
+
+
+def build_rope_cache(
+    seq_len: int,
+    n_elem: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    base: int = 10000,
+) -> torch.Tensor:
+    """Enhanced Transformer with Rotary Position Embedding.
+
+    Derived from: https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/labml_nn/
+    transformers/rope/__init__.py. MIT License:
+    https://github.com/labmlai/annotated_deep_learning_paper_implementations/blob/master/license.
+    """
+    # $\Theta = {\theta_i = 10000^{\frac{2(i-1)}{d}}, i \in [1, 2, ..., \frac{d}{2}]}$
+    theta = 1.0 / (
+        base ** (torch.arange(0, n_elem, 2, dtype=dtype, device=device) / n_elem)
+    )
+
+    # Create position indexes `[0, 1, ..., seq_len - 1]`
+    seq_idx = torch.arange(seq_len, dtype=dtype, device=device)
+
+    # Calculate the product of position index and $\theta_i$
+    idx_theta = torch.outer(seq_idx, theta).float()
+
+    cache = torch.stack([torch.cos(idx_theta), torch.sin(idx_theta)], dim=-1)
+
+    # this is to mimic the behaviour of complex32, else we will get different results
+    if dtype in (torch.float16, torch.bfloat16, torch.int8):
+        cache = cache.half()
+    return cache
+
+
+def apply_rope(x: torch.Tensor, rope_cache: torch.Tensor) -> torch.Tensor:
+    x = x.transpose(1, 2)
+
+    # truncate to support variable sizes
+    T = x.size(1)
+    rope_cache = rope_cache[:T]
+
+    # cast because the reference does
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    rope_cache = rope_cache.view(1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * rope_cache[..., 0] - xshaped[..., 1] * rope_cache[..., 1],
+            xshaped[..., 1] * rope_cache[..., 0] + xshaped[..., 0] * rope_cache[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.transpose(1, 2).type_as(x)
+
+
+class LagGPTFlowsModel(nn.Module):
+    def __init__(
+        self,
+        prediction_length: int,
+        context_length: int,
+        scaling: str,
+        input_size: int,
+        n_layer: int,
+        n_embd: int,
+        n_head: int,
+        dsf_marginal: Dict[str, Any],
+        num_parallel_samples: int = 100,
+    ) -> None:
+        super().__init__()
+        self.lags_seq = sorted(
+            list(
+                set(
+                    get_lags_for_frequency(freq_str="Q", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="M", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="W", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="D", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="H", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="T", num_default_lags=1)
+                    + get_lags_for_frequency(freq_str="S", num_default_lags=1)
+                )
+            )
+        )
+        config = LTSMConfig(
+            n_layer=n_layer,
+            n_embd=n_embd,
+            n_head=n_head,
+            block_size=context_length + prediction_length,
+            feature_size=input_size * (len(self.lags_seq)) + 2,
+        )
+        self.context_length = context_length
+        self.prediction_length = prediction_length
+        self.num_parallel_samples = num_parallel_samples
+
+        if scaling == "mean":
+            self.scaler = MeanScaler(keepdim=True, dim=1)
+        elif scaling == "std":
+            self.scaler = StdScaler(keepdim=True, dim=1)
+        else:
+            self.scaler = NOPScaler(keepdim=True, dim=1)
+
+        self.min_u, self.max_u = 0.05, 0.95
+        self.marginal = DSFMarginal(context_dim=config.n_embd, **dsf_marginal)
+
+        self.transformer = nn.ModuleDict(
+            dict(
+                wte=nn.Linear(config.feature_size, config.n_embd),
+                h=nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
+                ln_f=RMSNorm(config.n_embd),
+            )
+        )
+
+    @property
+    def _past_length(self) -> int:
+        return self.context_length + max(self.lags_seq)
+
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            torch.nn.init.normal_(
+                module.weight, mean=0.0, std=0.02 / math.sqrt(2 * self.config.n_layer)
+            )
+        elif isinstance(module, nn.Embedding):
+            torch.nn.init.normal_(
+                module.weight, mean=0.0, std=0.02 / math.sqrt(2 * self.config.n_layer)
+            )
+
+    def prepare_input(
+        self,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        future_target: Optional[torch.Tensor] = None,
+    ):
+        scaled_past_target, loc, scale = self.scaler(past_target, past_observed_values) # Data is standardized (past_observed_values is passed as "weights" parameter)
+
+        if future_target is not None:
+            future_length = future_target.shape[1] # pred_len
+            input = torch.cat(
+                (
+                    scaled_past_target[..., -self.context_length :], # Just the context
+                    (future_target[..., : future_length - 1] - loc) / scale, # Not sure about the -1 here
+                ),
+                dim=-1,
+            ) # Shape is (bsz, context_length+(pred_len-1))
+        else:
+            input = scaled_past_target[..., -self.context_length :]
+
+        prior_input = (past_target[..., : -self.context_length] - loc) / scale # This the history used to construct lags. NOTE: Why is prediction not used in the lags? (LAST PREDICTION TOKEN SHOULD BE USE THE PREDICTION WINDOW FOR THE LAG)
+        lags = lagged_sequence_values(self.lags_seq, prior_input, input, dim=-1) # Lags are added as an extra dim. Shape is (bsz, context_length+(pred_len-1), len(self.lags_seq)) # QUESTION: Are lags not added for the prediction window?
+
+        static_feat = torch.cat((loc.abs().log1p(), scale.log()), dim=-1) # (bsz, 2) (loc and scale are concatenated)
+        expanded_static_feat = unsqueeze_expand(
+            static_feat, dim=-2, size=lags.shape[-2]
+        ) # (bsz, context_length+(pred_len-1), 2)
+        # return: (bsz, context_length+(pred_len-1), len(self.lags_seq) + 2); (bsz, 1); (bsz, 1)
+        return torch.cat((lags, expanded_static_feat), dim=-1), input, loc, scale
+
+    def forward(
+        self,
+        past_target: torch.Tensor,
+        past_observed_values: torch.Tensor,
+        future_target: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        transformer_input, scaled_input, loc, scale = self.prepare_input(
+            past_target=past_target,
+            past_observed_values=past_observed_values,
+            future_target=future_target,
+        ) # return: (bsz, context_length+(pred_len-1), len(self.lags_seq) + 2); (bsz, 1); (bsz, 1)
+
+        # forward the LLaMA model itself
+        x = self.transformer.wte(
+            transformer_input
+        )  # (bsz, context_length+(pred_len-1), n_embd)
+
+        for block in self.transformer.h:
+            x = block(x)
+        x = self.transformer.ln_f(x) # (bsz, context_length+(pred_len-1), n_embd)
+
+        return x, scaled_input, loc, scale

--- a/lag-gpt-flows/run.sh
+++ b/lag-gpt-flows/run.sh
@@ -1,0 +1,6 @@
+for SEED in 1 # 2 3 4 5
+do
+    NAME="default_config_run"
+    python lag-gpt-flows/lag-gpt-flows-scaling-data.py \
+    lag-gpt-flows/configs/config.yaml --suffix "${NAME}" --seed $SEED
+done

--- a/lag-gpt/lag-gpt-scaling-data.py
+++ b/lag-gpt/lag-gpt-scaling-data.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 
 from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.dataset.repository.datasets import get_dataset
-from pytorch_lightning.loggers import CSVLogger
+from pytorch_lightning.loggers import CSVLogger, WandbLogger
 
 from estimator import LagGPTEstimator
 from pathlib import Path

--- a/lag-transformer/lag-transformer-scaling-data.py
+++ b/lag-transformer/lag-transformer-scaling-data.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 
 from gluonts.evaluation import make_evaluation_predictions, Evaluator
 from gluonts.dataset.repository.datasets import get_dataset
-from pytorch_lightning.loggers import CSVLogger
+from pytorch_lightning.loggers import CSVLogger, WandbLogger
 
 from estimator import LagTransformerEstimator
 


### PR DESCRIPTION
1. Fixed two minor bugs with the main files of Lag-GPT and Lag-Transformer: WandbLogger wasn't imported

2. Added Lag-GPT-with-Flows with a default config and bash script.
Lag-GPT-with-Flows uses some extra arguments using argparse that are convenient for launching different experiments and with multiple seeds. 
If required, I can make another PR modifying the main files of Lag-GPT and Lag-Transformer to look the same (it can be made backward compatible and non-breaking).